### PR TITLE
fix: fix XCTest linking issue for UI Tests targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,20 @@ Run `pod install` then open RSDKUtils.xcworkspace and run `Tests` target.
 ### Test Swift Package
 Open `Package.swift` in Xcode, choose iOS Simulator and run `Tests` target. 
 
-⚠️ **WARNING:** Command-line testing is not available at the moment because of bug https://bugs.swift.org/browse/SR-13773
+⚠️ **WARNING:** Command-line testing is not available at the moment because of bug [https://bugs.swift.org/browse/SR-13773](https://bugs.swift.org/browse/SR-13773)
 ```
 swift package clean
 swift test -Xswiftc "-sdk" -Xswiftc `xcrun --sdk iphonesimulator --show-sdk-path` -Xswiftc "-target" -Xswiftc "x86_64-apple-ios14.5-simulator"
+```
+
+# Troubleshooting
+
+* `dyld: Symbol not found:` error when running tests (Cocoapods version)
+
+This usually happens when `TestHelpers` or `Nimble` subspec is linked only to tests target where Host app target is linked to other RSDKUtils subspec at the same time. More info can be found here: [https://github.com/CocoaPods/CocoaPods/issues/7195](https://github.com/CocoaPods/CocoaPods/issues/7195)<br>
+The solution for that is to link `TestHelpers` and `Nimble` spec to the Host app target either explicitly or as a `testspecs`.
+```ruby
+target 'HostAppTarget'
+  pod 'RSDKUtils', '~> 2.0', :testspecs => ['Nimble', 'TestHelpers']
+end    
 ```

--- a/RSDKUtils.podspec
+++ b/RSDKUtils.podspec
@@ -26,9 +26,10 @@ Pod::Spec.new do |s|
   ]
   s.module_map = './RSDKUtils.modulemap'
   s.default_subspec = 'Main'
+  s.source_files = 'Sources/*.h'
+  s.public_header_files = 'Sources/*.h'
 
   s.subspec 'Main' do |ss|
-    ss.public_header_files = 'Sources/*.h'
     ss.source_files = 'Sources/RSDKUtilsMain/**/*.swift', 'Sources/*.h'
     ss.dependency 'RSDKUtils/RLogger'
   end
@@ -38,6 +39,10 @@ Pod::Spec.new do |s|
     ss.weak_frameworks = [
       'XCTest'
     ]
+    ss.pod_target_xcconfig = {
+      'ENABLE_TESTING_SEARCH_PATHS' => 'YES',
+      'OTHER_LDFLAGS'               => '$(inherited) -weak-lXCTestSwiftSupport'
+    }
     ss.dependency 'RSDKUtils/Main'
   end
 
@@ -49,7 +54,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'RLogger' do |ss|
     ss.source_files = 'Sources/RLogger/**/*.swift', 'Sources/*.h'
-    ss.public_header_files = 'Sources/*.h'
   end
 end
 # vim:syntax=ruby:et:sts=2:sw=2:ts=2:ff=unix:

--- a/Sources/RSDKUtilsMain/Lockable.swift
+++ b/Sources/RSDKUtilsMain/Lockable.swift
@@ -95,9 +95,9 @@ public class LockableObject<T>: LockableResource {
 
     private func checkIfThreadShouldWait(threadSafe: Bool) -> Bool {
         let currentThread = Thread.current
-        let shouldWait: () -> Bool = { [self] in
-            assert(!(_isLocked && lockingThread == nil), "Thread was deallocated before calling unlock()")
-            return _isLocked && lockingThread != nil && lockingThread != currentThread
+        let shouldWait: () -> Bool = {
+            assert(!(self._isLocked && self.lockingThread == nil), "Thread was deallocated before calling unlock()")
+            return self._isLocked && self.lockingThread != nil && self.lockingThread != currentThread
         }
         return threadSafe ? transactionQueue.sync(execute: shouldWait) : shouldWait()
     }


### PR DESCRIPTION
Fixes `dyld: Library not loaded: @rpath/libXCTestSwiftSupport.dylib` runtime error.

`pod lib lint` passed.