### PR TITLE
feat: migrate device id module SDKCF-4336

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,9 @@ let package = Package(
             name: "RSDKUtilsNimble",
             targets: ["RSDKUtilsNimble"]),
         .library(
+            name: "RDeviceIdentifier",
+            targets: ["RDeviceIdentifier"]),
+        .library(
             name: "RLogger",
             targets: ["RLogger"])
     ],
@@ -25,6 +28,9 @@ let package = Package(
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.1.0"))
     ],
     targets: [
+        .target(
+            name: "RDeviceIdentifier",
+            dependencies: ["RSDKUtilsMain"]),
         .target(name: "RLogger"),
         .target(
             name: "RSDKUtilsMain",
@@ -37,7 +43,7 @@ let package = Package(
             dependencies: ["RSDKUtilsMain", "Nimble"]),
         .testTarget(
             name: "Tests",
-            dependencies: ["RSDKUtilsMain", "RSDKUtilsNimble", "RSDKUtilsTestHelpers", "RLogger", "Quick", "Nimble"])
+            dependencies: ["RSDKUtilsMain", "RSDKUtilsNimble", "RSDKUtilsTestHelpers", "RDeviceIdentifier", "RLogger", "Quick", "Nimble"])
     ],
     swiftLanguageVersions: [
         .v5

--- a/Podfile
+++ b/Podfile
@@ -13,6 +13,7 @@ target 'Tests' do
   pod 'RSDKUtils/TestHelpers', :path => './RSDKUtils.podspec'
   pod 'RSDKUtils/Nimble', :path => './RSDKUtils.podspec'
   pod 'RSDKUtils/RLogger', :path => './RSDKUtils.podspec'
+  pod 'RSDKUtils/RDeviceIdentifier', :path => './RSDKUtils.podspec'
 end
 
 # vim:syntax=ruby:et:sts=2:sw=2:ts=2:ff=unix:

--- a/RSDKUtils.podspec
+++ b/RSDKUtils.podspec
@@ -55,5 +55,10 @@ Pod::Spec.new do |s|
   s.subspec 'RLogger' do |ss|
     ss.source_files = 'Sources/RLogger/**/*.swift', 'Sources/*.h'
   end
+
+  s.subspec 'RDeviceIdentifier' do |ss|
+    ss.source_files = 'Sources/RDeviceIdentifier/**/*.swift'
+    ss.dependency 'RSDKUtils/Main'
+  end
 end
 # vim:syntax=ruby:et:sts=2:sw=2:ts=2:ff=unix:

--- a/RSDKUtils.xcodeproj/project.pbxproj
+++ b/RSDKUtils.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		4597CFB126E69D4400781E4F /* TypedDependencyManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597CFB026E69D4400781E4F /* TypedDependencyManagerSpec.swift */; };
 		4597CFB326E69D7400781E4F /* AnyDependenciesContainerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597CFB226E69D7400781E4F /* AnyDependenciesContainerSpec.swift */; };
 		4597CFB526E6A6E300781E4F /* SwiftyDependenciesContainerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597CFB426E6A6E300781E4F /* SwiftyDependenciesContainerSpec.swift */; };
+		4B32DFCB272BFB09006531C4 /* RDeviceIdentifierSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B32DFCA272BFB09006531C4 /* RDeviceIdentifierSpec.swift */; };
 		6DACF499237CF05E00EEFE12 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DACF498237CF05E00EEFE12 /* TestHelpers.swift */; };
 		73CFF4FC271E56A700D2E36B /* AnalyticsBroadcasterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CFF4FB271E56A700D2E36B /* AnalyticsBroadcasterSpec.swift */; };
 		C97AB9742727234400F3BAB8 /* StringExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = C97AB9722727234400F3BAB8 /* StringExtensionsSpec.swift */; };
@@ -55,6 +56,8 @@
 		4597CFB226E69D7400781E4F /* AnyDependenciesContainerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyDependenciesContainerSpec.swift; sourceTree = "<group>"; };
 		4597CFB426E6A6E300781E4F /* SwiftyDependenciesContainerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftyDependenciesContainerSpec.swift; sourceTree = "<group>"; };
 		45EA75A825C76660001B2049 /*  */ = {isa = PBXFileReference; lastKnownFileType = folder; name = ""; sourceTree = "<group>"; };
+		4B32DFCA272BFB09006531C4 /* RDeviceIdentifierSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RDeviceIdentifierSpec.swift; sourceTree = "<group>"; };
+		4B6B35D1272F822A009C7F6D /* TestHost.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestHost.entitlements; sourceTree = "<group>"; };
 		529DB22D78CBF2B97EF675FE /* EnvironmentInformationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EnvironmentInformationTests.swift; sourceTree = "<group>"; };
 		6DACF498237CF05E00EEFE12 /* TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHelpers.swift; sourceTree = "<group>"; };
 		73CFF4FB271E56A700D2E36B /* AnalyticsBroadcasterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsBroadcasterSpec.swift; sourceTree = "<group>"; };
@@ -98,6 +101,7 @@
 		45EA75A725C7624F001B2049 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				4B32DFCA272BFB09006531C4 /* RDeviceIdentifierSpec.swift */,
 				C97AB9732727234400F3BAB8 /* DictionaryExtensionsSpec.swift */,
 				C97AB9722727234400F3BAB8 /* StringExtensionsSpec.swift */,
 				529DB22D78CBF2B97EF675FE /* EnvironmentInformationTests.swift */,
@@ -141,6 +145,7 @@
 		A9DCA0F399BA173C3556B928 = {
 			isa = PBXGroup;
 			children = (
+				4B6B35D1272F822A009C7F6D /* TestHost.entitlements */,
 				45EA75A825C76660001B2049 /*  */,
 				725C32805DD3F9A3B31E3A5E /* Products */,
 				C07BF9ACDD1012D4C6AA1A6B /* Tests */,
@@ -302,6 +307,7 @@
 				4597CFAF26E6952400781E4F /* LockableSpec.swift in Sources */,
 				4597CFB126E69D4400781E4F /* TypedDependencyManagerSpec.swift in Sources */,
 				4597CFAD26E6951200781E4F /* AtomicWrapperSpec.swift in Sources */,
+				4B32DFCB272BFB09006531C4 /* RDeviceIdentifierSpec.swift in Sources */,
 				45000A8F27173D31001962BF /* ReachabilitySpec.swift in Sources */,
 				6DACF499237CF05E00EEFE12 /* TestHelpers.swift in Sources */,
 				4597CFB526E6A6E300781E4F /* SwiftyDependenciesContainerSpec.swift in Sources */,
@@ -481,6 +487,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = TestHost.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/TestHost/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -495,6 +502,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = TestHost.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/TestHost/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Sources/RDeviceIdentifier/RDeviceIdentifier.swift
+++ b/Sources/RDeviceIdentifier/RDeviceIdentifier.swift
@@ -1,0 +1,139 @@
+import UIKit.UIDevice
+import CommonCrypto
+#if !canImport(RSDKUtils)
+import RLogger // Required in SPM version
+#endif
+
+@objc public final class RDeviceIdentifier: NSObject {
+    private static let keychain = RDeviceIdentifierKeychain()
+    private static var _uniqueDeviceIdentifier: String?
+
+    // MARK: - Public API
+
+    /// Return a string uniquely identifying the device the application is currently running on.
+    ///
+    /// - Warning: For this method to work, keychain access **MUST** be properly configured first.
+    ///            Please refer to internal Analytics SDK README’s Getting Started guide for important
+    ///            additional requirements for using this feature correctly.
+    ///            Also, the method will fail if the device is not unlocked at the time of calling.
+    ///
+    /// This value is initially derived from `-[UIDevice identifierForVendor]`, then
+    /// stored in a keychain item made accessible to other applications. This has a number of
+    /// benefits:
+    ///
+    /// Feature                                                       | `-[UIDevice identifierForVendor]` | `-[RDeviceIdentifier uniqueDeviceIdentifier]`
+    /// ------------------------------------------------------------- | --------------------------------- | ------------------------------------------------
+    /// Universally unique                                            | YES                               | YES
+    /// Restored from device backups, but only on the original device | YES                               | YES
+    /// Survives OS update                                            | YES                               | YES
+    /// Survives application update                                   | YES                               | YES
+    /// Survives application uninstall                                | YES                               | YES
+    /// Survives all applications being uninstalled ¹                 | NO                                | YES
+    ///
+    /// 1. If an application is reinstalled after all have been uninstalled,
+    ///    iOS resets the value to be returned by `-[UIDevice identifierForVendor]`.
+    ///
+    /// - Warning: Applications built with different application identifier prefixes/bundle seed identifiers, i.e.
+    ///          different provisioning profiles, will not produce the same device identifier.
+    ///
+    /// - Returns: A string uniquely identifying the device the application is currently running on.
+    ///         If the keychain is not available (i.e. the device is locked) and no value has been
+    ///         retrieved yet, `nil` is returned and the developer should try again when the device
+    ///         is unlocked.
+    @objc public static var uniqueDeviceIdentifier: String? {
+        // If we already have a value, return it.
+        if let _uniqueDeviceIdentifier = _uniqueDeviceIdentifier {
+            return _uniqueDeviceIdentifier
+        }
+
+        var accessGroup: String?
+        do {
+            if let (internalAccessGroup, defaultAccessGroup) = try keychain.getAccessGroups() {
+                accessGroup = internalAccessGroup
+                checkKeychainAccessGroupOrder(defaultAccessGroup)
+            }
+        } catch {
+            // Keychain is not available
+            RLogger.debug(message: "Keychain access failed")
+            return nil
+        }
+
+        // Try to clean things up
+        reset()
+
+        // Try to find the device identifier in the keychain.
+        // Here we always have a bundle seed id.
+        do {
+            if let accessGroup = accessGroup, let uniqueDeviceIdData = try keychain.search(for: accessGroup) {
+                // Device id found!
+                _uniqueDeviceIdentifier = uniqueDeviceIdData.hexString
+                return _uniqueDeviceIdentifier
+            }
+        } catch {
+            // Keychain problem
+            RLogger.debug(message: "Keychain access failed")
+            return nil
+        }
+
+        // Get identifierForVendor and write it to the keychain.
+        // If it succeeds, then assign the result to '_deviceIdData'.
+        var deviceIdData: Data?
+        guard var idForVendor = UIDevice.current.identifierForVendor?.uuidString else {
+            RLogger.debug(message: "Device must be unlocked first time after restart")
+            return nil
+        }
+        // Filter out nil, empty, or zeroed strings (e.g. "00000000-0000-0000-0000-000000000000")
+        // We don't have many options here, beside generating an id.
+        if !idForVendor.trimmingCharacters(in: CharacterSet(charactersIn: "0-")).isEmpty {
+            idForVendor = UUID().uuidString
+        }
+
+        if let strData = idForVendor.data(using: .utf8) {
+            var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+            _ = strData.withUnsafeBytes {
+                CC_SHA1($0.baseAddress, CC_LONG(strData.count), &digest)
+            }
+            deviceIdData = Data(bytes: &digest, count: Int(CC_SHA1_DIGEST_LENGTH))
+        }
+
+        guard let deviceIdData = deviceIdData,
+              let accessGroup = accessGroup,
+              (try? keychain.save(data: deviceIdData, for: accessGroup)) != nil else {
+            RLogger.debug(message: "Keychain access failed")
+            return nil
+        }
+
+        _uniqueDeviceIdentifier = deviceIdData.hexString
+        return _uniqueDeviceIdentifier
+}
+
+    /// Return the model identifier of the device the application is currently running on.
+    ///
+    /// - Returns: The internal model identifier. See [here](https://www.theiphonewiki.com/wiki/Models) for a list of model identifiers.
+    @objc public static var modelIdentifier: String {
+        // https://opensource.apple.com/source/xnu/xnu-201/bsd/sys/utsname.h.auto.html
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        // utsname.machine is a null terminated C-string
+        // make String from a ptr to the first bit (0)
+        return String(cString: &systemInfo.machine.0)
+    }
+
+    // MARK: - Helpers
+
+    private static func checkKeychainAccessGroupOrder(_ defaultAccessGroup: String) {
+        if let firstStopIndex = defaultAccessGroup.firstIndex(of: ".") {
+            let indexAfterStop = defaultAccessGroup.index(after: firstStopIndex)
+            let bundleId = String(defaultAccessGroup[indexAfterStop...])
+            if RDeviceIdentifierConstants.keychainAccessGroup == bundleId {
+                assertionFailure("\(RDeviceIdentifierConstants.keychainAccessGroup) is your default access group." +
+                        "Make sure your application's bundle identifier is the first entry of `keychain-access-groups` in your entitlements!")
+            }
+        }
+    }
+
+    static func reset() {
+        _uniqueDeviceIdentifier = nil
+        keychain.clear()
+    }
+}

--- a/Sources/RDeviceIdentifier/RDeviceIdentifierConstants.swift
+++ b/Sources/RDeviceIdentifier/RDeviceIdentifierConstants.swift
@@ -1,0 +1,4 @@
+enum RDeviceIdentifierConstants {
+    static let keychainAccessGroup = "com.rakuten.rdeviceinformation"
+    static let serviceKey = keychainAccessGroup + "probe"
+}

--- a/Sources/RDeviceIdentifier/RDeviceIdentifierKeychain.swift
+++ b/Sources/RDeviceIdentifier/RDeviceIdentifierKeychain.swift
@@ -1,0 +1,115 @@
+import Foundation
+#if !canImport(RSDKUtils)
+import RSDKUtilsMain // Required in SPM version
+#endif
+
+// MARK: - RDeviceIdentifierKeychain
+
+struct RDeviceIdentifierKeychain {
+    func getAccessGroups() throws -> (internalAccessGroup: String, defaultAccessGroup: String)? {
+        // First, try to grab the application identifier prefix (=bundle seed it)
+        // and build the access group from it.
+        do {
+            guard let result = try addIfNonExistent(),
+                  let defaultAccessGroup = result[String(kSecAttrAccessGroup)] as? String,
+                  let teamName = defaultAccessGroup.components(separatedBy: ".").first else {
+                return nil
+            }
+            let accessGroup = "\(teamName).\(RDeviceIdentifierConstants.keychainAccessGroup)"
+            return (accessGroup, defaultAccessGroup)
+        } catch let err {
+            throw err
+        }
+    }
+
+    func search(for accessGroup: String) throws -> Data? {
+        // Try to find the device identifier in the keychain.
+        // Here we always have a bundle seed id.
+        var searchQuery = query
+        searchQuery[String(kSecMatchLimit)] = kSecMatchLimitOne
+        searchQuery[String(kSecReturnData)] = true
+        searchQuery[String(kSecAttrAccessGroup)] = accessGroup
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(searchQuery as CFDictionary, &result)
+        try checkMissingAccessControl(status)
+
+        if status == errSecSuccess, let result = result as? Data {
+            return result
+        }
+        if status != errSecItemNotFound {
+            throw KeychainError.keychainLocked
+        }
+
+        return nil
+    }
+
+    func save(data: Data, for accessGroup: String) throws {
+        var saveQuery = query
+        saveQuery[String(kSecAttrAccessible)] = kSecAttrAccessibleWhenUnlocked
+        saveQuery[String(kSecValueData)] = data
+        saveQuery[String(kSecAttrAccessGroup)] = accessGroup
+
+        let status = SecItemAdd(saveQuery as CFDictionary, nil)
+        try checkMissingAccessControl(status)
+        guard status == errSecSuccess else {
+            throw KeychainError.queryFailed(status: status)
+        }
+    }
+
+    func clear() {
+        SecItemDelete(query as CFDictionary)
+    }
+
+    // MARK: - Helpers
+
+    private var query: [String: Any] {
+        [String(kSecAttrService): RDeviceIdentifierConstants.serviceKey,
+         String(kSecAttrAccount): RDeviceIdentifierConstants.serviceKey,
+         String(kSecClass): kSecClassGenericPassword]
+    }
+
+    private func addIfNonExistent() throws -> [String: Any]? {
+        var strongQuery = query
+        strongQuery[String(kSecAttrAccessible)] = kSecAttrAccessibleWhenUnlocked
+        strongQuery[String(kSecReturnAttributes)] = true
+        var result: CFTypeRef?
+        var status = SecItemCopyMatching(strongQuery as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            status = SecItemAdd(strongQuery as CFDictionary, &result)
+        }
+        if status != errSecSuccess {
+            throw KeychainError.keychainLocked
+        }
+
+        return result as? [String: Any]
+    }
+
+    private func checkMissingAccessControl(_ status: OSStatus?) throws {
+        // errSecNoAccessForItem is not defined for iOS, only OS X.
+        // Normally it would be found in <Security/SecBase.h>.
+        if status == errSecNoAccessForItem || status == errSecMissingEntitlement {
+            throw KeychainError.accessControl
+        }
+    }
+}
+
+// MARK: - KeychainError
+
+private enum KeychainError: Error {
+    case accessControl
+    case keychainLocked
+    case queryFailed(status: OSStatus)
+    case internalError
+}
+
+extension KeychainError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .accessControl: return "Your application is lacking the proper keychain-access-group entitlements."
+        case .keychainLocked: return "Keychain locked"
+        case .queryFailed(let status): return "Keychain query failed with code \(status)"
+        case .internalError: return "Internal error"
+        }
+    }
+}

--- a/TestHost.entitlements
+++ b/TestHost.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+		<string>$(AppIdentifierPrefix)com.rakuten.rdeviceinformation</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/Tests/RDeviceIdentifierSpec.swift
+++ b/Tests/Tests/RDeviceIdentifierSpec.swift
@@ -1,0 +1,85 @@
+import Quick
+import Nimble
+#if canImport(RSDKUtils)
+// Cocoapods version
+@testable import class RSDKUtils.RDeviceIdentifier
+@testable import struct RSDKUtils.RDeviceIdentifierKeychain
+@testable import enum RSDKUtils.RDeviceIdentifierConstants
+#else
+@testable import RDeviceIdentifier
+@testable import RSDKUtilsMain
+#endif
+
+// MARK: - RDeviceIdentifierSpec
+
+final class RDeviceIdentifierSpec: QuickSpec {
+    override func spec() {
+        describe("Test Device Id") {
+            beforeEach {
+                RDeviceIdentifier.reset()
+            }
+
+            it("will not be nil") {
+                let udid = RDeviceIdentifier.uniqueDeviceIdentifier
+                expect(udid).toNot(beNil())
+            }
+
+            it("has length") {
+                let udid = RDeviceIdentifier.uniqueDeviceIdentifier
+                expect(udid?.count) > 0
+            }
+
+            it("should return same value when called twice") {
+                let udid = RDeviceIdentifier.uniqueDeviceIdentifier
+                expect(udid).to(equal(RDeviceIdentifier.uniqueDeviceIdentifier))
+            }
+        }
+
+        describe("Test Model Id") {
+            it("has model id") {
+                let expectedValues = ["i386", "x86_64", "arm64"]
+                #if targetEnvironment(simulator)
+                expect(expectedValues).to(contain(RDeviceIdentifier.modelIdentifier))
+                #else
+                expect(expectedValues).toNot(contain(RDeviceIdentifier.modelIdentifier))
+                #endif
+            }
+        }
+
+        describe("Test keychain") {
+            var keychain: RDeviceIdentifierKeychain!
+
+            beforeEach {
+                keychain = RDeviceIdentifierKeychain()
+                keychain.clear()
+            }
+
+            it("should get internal access groups") {
+                expect(try keychain.getAccessGroups()).toNot(throwError())
+                let results = try keychain.getAccessGroups()
+                expect(results).toNot(beNil())
+                let (internalAccessGroup, defaultAccessGroup) = results!
+                expect(internalAccessGroup.isEmpty).to(beFalse())
+                let hostBundleId = Bundle.main.bundleIdentifier!
+                expect(defaultAccessGroup).to(contain(hostBundleId))
+            }
+
+            it("should save and retrieve value to internal access group") {
+                let (internalAccessGroup, _) = try keychain.getAccessGroups()!
+                let expected = "abc"
+                let text = expected.data(using: .utf8)!
+                expect(try? keychain.save(data: text, for: internalAccessGroup)).toNot(throwError())
+                expect(try? keychain.search(for: internalAccessGroup)).toNot(throwError())
+                expect(try? keychain.search(for: internalAccessGroup)).to(equal(text))
+            }
+
+            it("should clear keychain for internal access group") {
+                let (internalAccessGroup, _) = try keychain.getAccessGroups()!
+                let text = "abc".data(using: .utf8)!
+                expect(try? keychain.save(data: text, for: internalAccessGroup)).toNot(throwError())
+                keychain.clear()
+                expect(try? keychain.search(for: internalAccessGroup)).to(beNil())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Migrated original deviceid module. Mostly a reproduction of the original code to maintain compatibility with Obj-C and the API contract.

## Major differences from original
* Swift
* reset cached `uniqueDeviceIdentifier` before each test
* removed cached `deviceIdData, saveQuery, accessGroup, searchQuery, zeroesAndHyphens` values from the `uniqueDeviceIdentifier` computed property -- don't think there's a gain holding onto these intermediate values especially when Keychain access itself is cached
* fixed test to pass on `arm64` (Apple Silicon)
* removed `@synchronized` 