### PR TITLE
SDKCF-4559 refactored RDeviceIdentifier API

### DIFF
--- a/Sources/RDeviceIdentifier/RDeviceIdentifierConstants.swift
+++ b/Sources/RDeviceIdentifier/RDeviceIdentifierConstants.swift
@@ -1,4 +1,0 @@
-enum RDeviceIdentifierConstants {
-    static let keychainAccessGroup = "com.rakuten.rdeviceinformation"
-    static let serviceKey = keychainAccessGroup + "probe"
-}

--- a/Sources/RDeviceIdentifier/RDeviceIdentifierError.swift
+++ b/Sources/RDeviceIdentifier/RDeviceIdentifierError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// MARK: - RDeviceIdentifierError
+
+public enum RDeviceIdentifierError: Error {
+    case accessControl
+    case appGroupEntitlements(accessGroup: String)
+    case keychainLocked
+    case keychainQueryFailed(status: OSStatus)
+}
+
+extension RDeviceIdentifierError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .accessControl: return "Device must be unlocked first time after restart."
+        case .appGroupEntitlements(let accessGroup): return "Your application is lacking keychain-access-group entitlements for \(accessGroup)."
+        case .keychainLocked: return "Keychain locked."
+        case .keychainQueryFailed(let status): return "Keychain query failed with code \(status)."
+        }
+    }
+}

--- a/Sources/RDeviceIdentifier/RDeviceIdentifierKeychain.swift
+++ b/Sources/RDeviceIdentifier/RDeviceIdentifierKeychain.swift
@@ -61,22 +61,6 @@ struct RDeviceIdentifierKeychain {
          String(kSecClass): kSecClassGenericPassword]
     }
 
-    private func addIfNonExistent() throws -> [String: Any]? {
-        var strongQuery = query
-        strongQuery[String(kSecAttrAccessible)] = kSecAttrAccessibleWhenUnlocked
-        strongQuery[String(kSecReturnAttributes)] = true
-        var result: CFTypeRef?
-        var status = SecItemCopyMatching(strongQuery as CFDictionary, &result)
-        if status == errSecItemNotFound {
-            status = SecItemAdd(strongQuery as CFDictionary, &result)
-        }
-        if status != errSecSuccess {
-            throw RDeviceIdentifierError.keychainLocked
-        }
-
-        return result as? [String: Any]
-    }
-
     private func checkMissingAccessControl(_ status: OSStatus, for accessGroup: String) throws {
         if status == errSecNoAccessForItem {
             throw RDeviceIdentifierError.accessControl

--- a/Sources/RDeviceIdentifier/RDeviceIdentifierKeychain.swift
+++ b/Sources/RDeviceIdentifier/RDeviceIdentifierKeychain.swift
@@ -1,27 +1,17 @@
 import Foundation
-#if !canImport(RSDKUtils)
-import RSDKUtilsMain // Required in SPM version
-#endif
 
 // MARK: - RDeviceIdentifierKeychain
 
 struct RDeviceIdentifierKeychain {
-    func getAccessGroups() throws -> (internalAccessGroup: String, defaultAccessGroup: String)? {
-        // First, try to grab the application identifier prefix (=bundle seed it)
-        // and build the access group from it.
-        do {
-            guard let result = try addIfNonExistent(),
-                  let defaultAccessGroup = result[String(kSecAttrAccessGroup)] as? String,
-                  let teamName = defaultAccessGroup.components(separatedBy: ".").first else {
-                return nil
-            }
-            let accessGroup = "\(teamName).\(RDeviceIdentifierConstants.keychainAccessGroup)"
-            return (accessGroup, defaultAccessGroup)
-        } catch let err {
-            throw err
-        }
+    let service: String
+    let accessGroup: String
+
+    init(service: String, accessGroup: String) {
+        self.service = service
+        self.accessGroup = accessGroup
     }
 
+    /// Queries keychain for Data associated with service and app access group
     func search(for accessGroup: String) throws -> Data? {
         // Try to find the device identifier in the keychain.
         // Here we always have a bundle seed id.
@@ -32,18 +22,19 @@ struct RDeviceIdentifierKeychain {
 
         var result: CFTypeRef?
         let status = SecItemCopyMatching(searchQuery as CFDictionary, &result)
-        try checkMissingAccessControl(status)
+        try checkMissingAccessControl(status, for: accessGroup)
 
         if status == errSecSuccess, let result = result as? Data {
             return result
         }
         if status != errSecItemNotFound {
-            throw KeychainError.keychainLocked
+            throw RDeviceIdentifierError.keychainLocked
         }
 
         return nil
     }
 
+    /// Saves to keychain Data on service and app access group
     func save(data: Data, for accessGroup: String) throws {
         var saveQuery = query
         saveQuery[String(kSecAttrAccessible)] = kSecAttrAccessibleWhenUnlocked
@@ -51,12 +42,13 @@ struct RDeviceIdentifierKeychain {
         saveQuery[String(kSecAttrAccessGroup)] = accessGroup
 
         let status = SecItemAdd(saveQuery as CFDictionary, nil)
-        try checkMissingAccessControl(status)
+        try checkMissingAccessControl(status, for: accessGroup)
         guard status == errSecSuccess else {
-            throw KeychainError.queryFailed(status: status)
+            throw RDeviceIdentifierError.keychainQueryFailed(status: status)
         }
     }
 
+    /// Clears all Keychain values associated with service and app access group
     func clear() {
         SecItemDelete(query as CFDictionary)
     }
@@ -64,8 +56,8 @@ struct RDeviceIdentifierKeychain {
     // MARK: - Helpers
 
     private var query: [String: Any] {
-        [String(kSecAttrService): RDeviceIdentifierConstants.serviceKey,
-         String(kSecAttrAccount): RDeviceIdentifierConstants.serviceKey,
+        [String(kSecAttrService): service,
+         String(kSecAttrAccount): service,
          String(kSecClass): kSecClassGenericPassword]
     }
 
@@ -79,37 +71,18 @@ struct RDeviceIdentifierKeychain {
             status = SecItemAdd(strongQuery as CFDictionary, &result)
         }
         if status != errSecSuccess {
-            throw KeychainError.keychainLocked
+            throw RDeviceIdentifierError.keychainLocked
         }
 
         return result as? [String: Any]
     }
 
-    private func checkMissingAccessControl(_ status: OSStatus?) throws {
-        // errSecNoAccessForItem is not defined for iOS, only OS X.
-        // Normally it would be found in <Security/SecBase.h>.
-        if status == errSecNoAccessForItem || status == errSecMissingEntitlement {
-            throw KeychainError.accessControl
+    private func checkMissingAccessControl(_ status: OSStatus, for accessGroup: String) throws {
+        if status == errSecNoAccessForItem {
+            throw RDeviceIdentifierError.accessControl
         }
-    }
-}
-
-// MARK: - KeychainError
-
-private enum KeychainError: Error {
-    case accessControl
-    case keychainLocked
-    case queryFailed(status: OSStatus)
-    case internalError
-}
-
-extension KeychainError: LocalizedError {
-    var errorDescription: String? {
-        switch self {
-        case .accessControl: return "Your application is lacking the proper keychain-access-group entitlements."
-        case .keychainLocked: return "Keychain locked"
-        case .queryFailed(let status): return "Keychain query failed with code \(status)"
-        case .internalError: return "Internal error"
+        if status == errSecMissingEntitlement {
+            throw RDeviceIdentifierError.appGroupEntitlements(accessGroup: accessGroup)
         }
     }
 }

--- a/TestHost.entitlements
+++ b/TestHost.entitlements
@@ -4,8 +4,8 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)$(PRODUCT_BUNDLE_IDENTIFIER)</string>
-		<string>$(AppIdentifierPrefix)com.rakuten.rdeviceinformation</string>
+		<string>com.rakuten.rdeviceidentifier</string>
+		<string>com.rakuten.rdeviceidentifier-dummy</string>
 	</array>
 </dict>
 </plist>

--- a/Tests/Tests/RDeviceIdentifierSpec.swift
+++ b/Tests/Tests/RDeviceIdentifierSpec.swift
@@ -2,9 +2,9 @@ import Quick
 import Nimble
 #if canImport(RSDKUtils)
 // Cocoapods version
-@testable import class RSDKUtils.RDeviceIdentifier
+@testable import enum RSDKUtils.RDeviceIdentifier
 @testable import struct RSDKUtils.RDeviceIdentifierKeychain
-@testable import enum RSDKUtils.RDeviceIdentifierConstants
+@testable import enum RSDKUtils.RDeviceIdentifierError
 #else
 @testable import RDeviceIdentifier
 @testable import RSDKUtilsMain
@@ -13,25 +13,32 @@ import Nimble
 // MARK: - RDeviceIdentifierSpec
 
 final class RDeviceIdentifierSpec: QuickSpec {
+    let service = "com.rakuten.rdeviceidentifier"
+    let accessGroup = "com.rakuten.rdeviceidentifier" // must be in TestHost.entitlements
+    var keychain: RDeviceIdentifierKeychain {
+        RDeviceIdentifierKeychain(service: service, accessGroup: accessGroup)
+    }
+
     override func spec() {
         describe("Test Device Id") {
             beforeEach {
-                RDeviceIdentifier.reset()
+                self.keychain.clear()
             }
 
             it("will not be nil") {
-                let udid = RDeviceIdentifier.uniqueDeviceIdentifier
+                let udid = try? RDeviceIdentifier.getUniqueDeviceIdentifier(service: self.service, accessGroup: self.accessGroup)
                 expect(udid).toNot(beNil())
             }
 
             it("has length") {
-                let udid = RDeviceIdentifier.uniqueDeviceIdentifier
+                let udid = try? RDeviceIdentifier.getUniqueDeviceIdentifier(service: self.service, accessGroup: self.accessGroup)
                 expect(udid?.count) > 0
             }
 
             it("should return same value when called twice") {
-                let udid = RDeviceIdentifier.uniqueDeviceIdentifier
-                expect(udid).to(equal(RDeviceIdentifier.uniqueDeviceIdentifier))
+                let udid1 = try? RDeviceIdentifier.getUniqueDeviceIdentifier(service: self.service, accessGroup: self.accessGroup)
+                let udid2 = try? RDeviceIdentifier.getUniqueDeviceIdentifier(service: self.service, accessGroup: self.accessGroup)
+                expect(udid1).to(equal(udid2))
             }
         }
 
@@ -50,35 +57,38 @@ final class RDeviceIdentifierSpec: QuickSpec {
             var keychain: RDeviceIdentifierKeychain!
 
             beforeEach {
-                keychain = RDeviceIdentifierKeychain()
+                keychain = self.keychain
                 keychain.clear()
             }
 
-            it("should get internal access groups") {
-                expect(try keychain.getAccessGroups()).toNot(throwError())
-                let results = try keychain.getAccessGroups()
-                expect(results).toNot(beNil())
-                let (internalAccessGroup, defaultAccessGroup) = results!
-                expect(internalAccessGroup.isEmpty).to(beFalse())
-                let hostBundleId = Bundle.main.bundleIdentifier!
-                expect(defaultAccessGroup).to(contain(hostBundleId))
-            }
-
-            it("should save and retrieve value to internal access group") {
-                let (internalAccessGroup, _) = try keychain.getAccessGroups()!
+            it("should save and retrieve value to same access group") {
                 let expected = "abc"
                 let text = expected.data(using: .utf8)!
-                expect(try? keychain.save(data: text, for: internalAccessGroup)).toNot(throwError())
-                expect(try? keychain.search(for: internalAccessGroup)).toNot(throwError())
-                expect(try? keychain.search(for: internalAccessGroup)).to(equal(text))
+                expect(try keychain.save(data: text, for: self.accessGroup)).toNot(throwError())
+                expect(try keychain.search(for: self.accessGroup)).toNot(throwError())
+                expect(try keychain.search(for: self.accessGroup)).to(equal(text))
             }
 
-            it("should clear keychain for internal access group") {
-                let (internalAccessGroup, _) = try keychain.getAccessGroups()!
+            it("should save to accessGroup1 and not find value on accessGroup2") {
+                let expected = "abc"
+                let text = expected.data(using: .utf8)!
+                let entitledDummyAccessGroup = self.accessGroup + "-dummy"
+                expect(try keychain.save(data: text, for: self.accessGroup)).toNot(throwError())
+                expect(try keychain.search(for: entitledDummyAccessGroup)).toNot(throwError())
+                expect(try keychain.search(for: entitledDummyAccessGroup)).to(beNil())
+            }
+
+            it("should throw error for unentitled access group") {
+                let unentitledAccessGroup = "no.access.group" // should NOT be in TestHost.entitlements
+                let expectedErr = RDeviceIdentifierError.appGroupEntitlements(accessGroup: unentitledAccessGroup)
+                expect(try keychain.search(for: unentitledAccessGroup)).to(throwError(expectedErr))
+            }
+
+            it("should clear keychain for access group") {
                 let text = "abc".data(using: .utf8)!
-                expect(try? keychain.save(data: text, for: internalAccessGroup)).toNot(throwError())
+                expect(try keychain.save(data: text, for: self.accessGroup)).toNot(throwError())
                 keychain.clear()
-                expect(try? keychain.search(for: internalAccessGroup)).to(beNil())
+                expect(try keychain.search(for: self.accessGroup)).to(beNil())
             }
         }
     }


### PR DESCRIPTION
Continuation of #21

## Notable Changes
* incompatible with Obj-C (use older version instead)
* API change: user must now explicitly provide `accessGroup` and `service` instead of being inferred
* API change: `throws` instead instead of `assertionFailure`
* dependency removal: doesn't use `RLogger`

## Public APIs
```swift
public enum RDeviceIdentifier {
    public static func getUniqueDeviceIdentifier(service: String, accessGroup: String) throws -> String
    public static var modelIdentifier: String
}
public enum RDeviceIdentifierError: Error {
    case accessControl
    case appGroupEntitlements(accessGroup: String)
    case keychainLocked
    case keychainQueryFailed(status: OSStatus)
}
```

If calling `RDeviceIdentifier.getUniqueDeviceIdentifier(service:accessGroup:)`, an `.entitlements` must be created with an id (used for Keychain Sharing). This should correspond the value passed into the `accessGroup` argument. 

![](https://user-images.githubusercontent.com/40610/67627072-333b1580-f890-11e9-9feb-bf507abc2724.png)