### PR TITLE
improve: improve sdk bundle search extension methods

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
   - Nimble (9.2.1)
   - Quick (4.0.0)
-  - RSDKUtils (2.0.0):
-    - RSDKUtils/Main (= 2.0.0)
-  - RSDKUtils/Main (2.0.0):
+  - RSDKUtils (2.1.0):
+    - RSDKUtils/Main (= 2.1.0)
+  - RSDKUtils/Main (2.1.0):
     - RSDKUtils/RLogger
-  - RSDKUtils/Nimble (2.0.0):
+  - RSDKUtils/Nimble (2.1.0):
     - Nimble
     - RSDKUtils/Main
-  - RSDKUtils/RLogger (2.0.0)
-  - RSDKUtils/TestHelpers (2.0.0):
+  - RSDKUtils/RLogger (2.1.0)
+  - RSDKUtils/TestHelpers (2.1.0):
     - RSDKUtils/Main
-  - SwiftLint (0.44.0)
+  - SwiftLint (0.45.1)
 
 DEPENDENCIES:
   - Nimble
@@ -35,8 +35,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Nimble: e7e615c0335ee4bf5b0d786685451e62746117d5
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  RSDKUtils: 0b3f04097bffc8c95912e62aa5e009f26b03a4fb
-  SwiftLint: e96c0a8c770c7ebbc4d36c55baf9096bb65c4584
+  RSDKUtils: 47d28aac1347d712e6d4db9a1332cae41b17738f
+  SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
 
 PODFILE CHECKSUM: a764aa703c4858c50bdac374e7ffb09622de0025
 

--- a/Sources/RSDKUtilsMain/Extensions/Bundle+EnvironmentInformation.swift
+++ b/Sources/RSDKUtilsMain/Extensions/Bundle+EnvironmentInformation.swift
@@ -36,12 +36,16 @@ extension Bundle: BundleProtocol {
 public extension Bundle {
 
     static func sdkBundle(name: String) -> Bundle? {
-        let defaultBundle = self.init(identifier: "org.cocoapods.\(name)") ?? .bundle(bundleIdSubstring: name)
+        let defaultBundle = self.init(identifier: "org.cocoapods.\(name)") ?? .frameworkBundle(bundleIdPhrase: name)
         assert(defaultBundle != nil, "\(name) SDK is not integrated properly - framework bundle not found")
         return defaultBundle
     }
 
-    static func bundle(bundleIdSubstring: String) -> Bundle? {
-        return (allBundles + allFrameworks).first(where: { $0.bundleIdentifier?.contains(bundleIdSubstring) == true })
+    static func assetsBundle(bundleIdPhrase: String) -> Bundle? {
+        allBundles.first(where: { $0.bundleIdentifier?.contains(bundleIdPhrase) == true })
+    }
+
+    static func frameworkBundle(bundleIdPhrase: String) -> Bundle? {
+        allFrameworks.first(where: { $0.bundleIdentifier?.contains(bundleIdPhrase) == true })
     }
 }

--- a/Sources/RSDKUtilsMain/Networking/Reachability.swift
+++ b/Sources/RSDKUtilsMain/Networking/Reachability.swift
@@ -186,7 +186,7 @@ public class Reachability: ReachabilityType {
     }
 
     private static func logDebug(_ message: String) {
-        RLogger.debug(message)
+        RLogger.debug(message: message)
     }
 }
 

--- a/Tests/Tests/AnalyticsBroadcasterSpec.swift
+++ b/Tests/Tests/AnalyticsBroadcasterSpec.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Quick
 import Nimble
 #if canImport(RSDKUtils)
@@ -28,8 +29,8 @@ final class AnalyticsBroadcasterSpec: QuickSpec {
             beforeEach {
                 tracker = AnalyticsTrackerMock()
                 observer = NotificationCenter.default.addObserver(forName: .sdkCustomEvent,
-                                                                      object: nil,
-                                                                      queue: OperationQueue()) { notification in
+                                                                  object: nil,
+                                                                  queue: OperationQueue()) { notification in
                     tracker?.trackEvent(name: NSNotification.Name.sdkCustomEvent.rawValue, parameters: notification.object as? [String: Any])
                     if let observer = observer {
                         NotificationCenter.default.removeObserver(observer)


### PR DESCRIPTION
When SDK has additional assets bundle, once it is loaded, `bundle(bundleIdSubstring: String)` method returns that bundle instead of framework bundle which impacts `sdkBundle(name: String)` and can end up in an assertion failure.