### PR TITLE
feat: Align Swift version support (SDKCF-4824)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,6 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ RSDKUtils consists of 4 sub-modules:
 
 This module supports iOS 11.0 and above. It has been tested with iOS 11.1 and above.
 
+# **Requirements**
+
+Xcode 12.5.x or Xcode 13+
+
+Swift >= 5.4 is supported.
+
+Note: The SDK may build on earlier Xcode versions but it is not officially supported or tested.
+
 # **How to install**
 
 ## Installing with CocoaPods

--- a/RSDKUtils.podspec
+++ b/RSDKUtils.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.source       = { :git => "https://github.com/rakutentech/ios-sdkutils.git", :tag => s.version.to_s }
   s.platform     = :ios, '11.0'
-  s.swift_version = '5.0'
+  s.swift_versions = ['5.4', '5.5']
   s.requires_arc = true
   s.pod_target_xcconfig = {
     'CLANG_ENABLE_MODULES'                                  => 'YES',


### PR DESCRIPTION
## Align Swift version support for all SDKs.

Our SDKs Readme files already mentions that only Xcode 12.5.x or Xcode 13+ are supported.

That means that we can drop the Xcode support for versions < 12.5.

Xcode 12.5 has Swift 5.4.

Then I propose to handle only Swift version >= 5.4.

Then we'll have ['5.4', '5.5'] in the podspec files.

## Notes
Swift 5.1 is included in Xcode 11: https://www.swift.org/blog/swift-5-1-released/
Swift 5.2 is included in Xcode 11.4: https://www.swift.org/blog/swift-5-2-released/
Swift 5.3 is included in Xcode 12: https://www.swift.org/blog/swift-5-3-released/

All Swift versions supported by Xcode:
https://swiftversion.net

## Links
SDKCF-4824