### PR TITLE
tests: improve unit tests coverage

### DIFF
--- a/.xcovignore
+++ b/.xcovignore
@@ -1,2 +1,0 @@
-- RSDKUtilsTestHelpers
-- RSDKUtilsNimble

--- a/Dangerfile
+++ b/Dangerfile
@@ -9,7 +9,6 @@ xcov.report(
   json_report: true,
   include_targets: 'RSDKUtils.framework',
   include_test_targets: false,
-  ignore_file_path: '.xcovignore',
-  minimum_coverage_percentage: 70.0,
+  minimum_coverage_percentage: 80.0,
   skip_slack: true
 )

--- a/RSDKUtils.xcodeproj/project.pbxproj
+++ b/RSDKUtils.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		452FA0F326EE974400936528 /* RLoggerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452FA0F226EE974400936528 /* RLoggerSpec.swift */; };
 		4535CBC52714E58200D6E5AF /* StandardHeaderSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4535CBC42714E58200D6E5AF /* StandardHeaderSpec.swift */; };
 		45741527271781A60059286F /* NSObjectExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45741526271781A60059286F /* NSObjectExtensionsSpec.swift */; };
+		4584C13727C80E1C00A1C6BC /* NimbleExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4584C13627C80E1C00A1C6BC /* NimbleExtensionsSpec.swift */; };
+		4584C13B27C81CAF00A1C6BC /* XCTestExtensionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4584C13A27C81CAF00A1C6BC /* XCTestExtensionsSpec.swift */; };
+		4584C13D27C8242500A1C6BC /* URLSessionMockSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4584C13C27C8242500A1C6BC /* URLSessionMockSpec.swift */; };
 		4597CFAD26E6951200781E4F /* AtomicWrapperSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597CFAC26E6951200781E4F /* AtomicWrapperSpec.swift */; };
 		4597CFAF26E6952400781E4F /* LockableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597CFAE26E6952400781E4F /* LockableSpec.swift */; };
 		4597CFB126E69D4400781E4F /* TypedDependencyManagerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4597CFB026E69D4400781E4F /* TypedDependencyManagerSpec.swift */; };
@@ -49,6 +52,9 @@
 		452FA0F226EE974400936528 /* RLoggerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RLoggerSpec.swift; sourceTree = "<group>"; };
 		4535CBC42714E58200D6E5AF /* StandardHeaderSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardHeaderSpec.swift; sourceTree = "<group>"; };
 		45741526271781A60059286F /* NSObjectExtensionsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectExtensionsSpec.swift; sourceTree = "<group>"; };
+		4584C13627C80E1C00A1C6BC /* NimbleExtensionsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbleExtensionsSpec.swift; sourceTree = "<group>"; };
+		4584C13A27C81CAF00A1C6BC /* XCTestExtensionsSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestExtensionsSpec.swift; sourceTree = "<group>"; };
+		4584C13C27C8242500A1C6BC /* URLSessionMockSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionMockSpec.swift; sourceTree = "<group>"; };
 		4597CFAC26E6951200781E4F /* AtomicWrapperSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AtomicWrapperSpec.swift; sourceTree = "<group>"; };
 		4597CFAE26E6952400781E4F /* LockableSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockableSpec.swift; sourceTree = "<group>"; };
 		4597CFB026E69D4400781E4F /* TypedDependencyManagerSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedDependencyManagerSpec.swift; sourceTree = "<group>"; };
@@ -116,6 +122,9 @@
 				45000A92271775C5001962BF /* URLSessionExtensionsSpec.swift */,
 				45741526271781A60059286F /* NSObjectExtensionsSpec.swift */,
 				73CFF4FB271E56A700D2E36B /* AnalyticsBroadcasterSpec.swift */,
+				4584C13627C80E1C00A1C6BC /* NimbleExtensionsSpec.swift */,
+				4584C13A27C81CAF00A1C6BC /* XCTestExtensionsSpec.swift */,
+				4584C13C27C8242500A1C6BC /* URLSessionMockSpec.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -290,6 +299,7 @@
 				45000A9127177394001962BF /* DataExtensionsSpec.swift in Sources */,
 				D06A23E924D3FF2800E84EE2 /* KeyStoreTests.swift in Sources */,
 				C97AB9752727234400F3BAB8 /* DictionaryExtensionsSpec.swift in Sources */,
+				4584C13B27C81CAF00A1C6BC /* XCTestExtensionsSpec.swift in Sources */,
 				4535CBC52714E58200D6E5AF /* StandardHeaderSpec.swift in Sources */,
 				C97AB9742727234400F3BAB8 /* StringExtensionsSpec.swift in Sources */,
 				452FA0F326EE974400936528 /* RLoggerSpec.swift in Sources */,
@@ -299,10 +309,12 @@
 				45000A93271775C5001962BF /* URLSessionExtensionsSpec.swift in Sources */,
 				4518EEDC270F6D9900E8CBBC /* UIColorExtensionsSpec.swift in Sources */,
 				4597CFB326E69D7400781E4F /* AnyDependenciesContainerSpec.swift in Sources */,
+				4584C13D27C8242500A1C6BC /* URLSessionMockSpec.swift in Sources */,
 				4597CFAF26E6952400781E4F /* LockableSpec.swift in Sources */,
 				4597CFB126E69D4400781E4F /* TypedDependencyManagerSpec.swift in Sources */,
 				4597CFAD26E6951200781E4F /* AtomicWrapperSpec.swift in Sources */,
 				45000A8F27173D31001962BF /* ReachabilitySpec.swift in Sources */,
+				4584C13727C80E1C00A1C6BC /* NimbleExtensionsSpec.swift in Sources */,
 				6DACF499237CF05E00EEFE12 /* TestHelpers.swift in Sources */,
 				4597CFB526E6A6E300781E4F /* SwiftyDependenciesContainerSpec.swift in Sources */,
 			);

--- a/Sources/RSDKUtilsTestHelpers/Extensions/XCTest+Eventually.swift
+++ b/Sources/RSDKUtilsTestHelpers/Extensions/XCTest+Eventually.swift
@@ -3,23 +3,27 @@ import XCTest
 
 public extension XCTestCase {
 
+    private static let eventuallyDispatchQueue = DispatchQueue(label: "XCTestHelper.eventually")
+
     func eventually<T: Equatable>(after time: TimeInterval = 5,
                                   this value: @escaping () -> T?,
                                   shouldEqual otherValue: @escaping () -> T) {
 
         let expectation = self.expectation(description: "eventually \(String(describing: value())) should equal \(String(describing: otherValue()))")
 
-        Timer.scheduledTimer(withTimeInterval: 0.5,
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.5,
                              repeats: true) { (timer) in
-            DispatchQueue.main.async {
+            XCTestCase.eventuallyDispatchQueue.async {
                 if value() == otherValue() {
                     expectation.fulfill()
                     timer.invalidate()
                 }
             }
-        }.fire()
+        }
+        timer.fire()
 
         wait(for: [expectation], timeout: time)
+        timer.invalidate()
         XCTAssertEqual(value(), otherValue())
     }
 }

--- a/Sources/RSDKUtilsTestHelpers/Extensions/XCTest+Eventually.swift
+++ b/Sources/RSDKUtilsTestHelpers/Extensions/XCTest+Eventually.swift
@@ -3,7 +3,9 @@ import XCTest
 
 public extension XCTestCase {
 
-    func eventually<T: Equatable>(after time: TimeInterval = 5, this value: @escaping () -> T?, shouldEqual otherValue: @escaping () -> T) {
+    func eventually<T: Equatable>(after time: TimeInterval = 5,
+                                  this value: @escaping () -> T?,
+                                  shouldEqual otherValue: @escaping () -> T) {
 
         let expectation = self.expectation(description: "eventually \(String(describing: value())) should equal \(String(describing: otherValue()))")
 

--- a/Sources/RSDKUtilsTestHelpers/URLSessionMock.swift
+++ b/Sources/RSDKUtilsTestHelpers/URLSessionMock.swift
@@ -78,6 +78,9 @@ public final class URLSessionMock: URLSession {
             guard let value = item.value else {
                 return nil
             }
+            if let boolValue = Bool(value) {
+                return "\"\(item.name)\": \(boolValue)"
+            }
             if let intValue = Int(value) {
                 return "\"\(item.name)\": \(intValue)"
             }

--- a/Tests/Tests/NimbleExtensionsSpec.swift
+++ b/Tests/Tests/NimbleExtensionsSpec.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Quick
+import Nimble
+#if canImport(RSDKUtils)
+@testable import RSDKUtils // Cocoapods version
+#else
+@testable import RSDKUtilsMain
+@testable import RSDKUtilsNimble
+#endif
+
+final class NimbleExtensionsSpec: QuickSpec {
+
+    override func spec() {
+        describe("Expectation extensions") {
+
+            context("toAfterTimeout()") {
+
+                it("should finish after expected default timeout (1s)") {
+                    let startTime = Date()
+                    expect("test").toAfterTimeout(haveCount(4))
+                    let secondsPaseed = Date().timeIntervalSince(startTime)
+                    expect(secondsPaseed).to(beGreaterThan(0.8))
+                    expect(secondsPaseed).to(beLessThan(1.2))
+                }
+
+                it("should finish after expected timeout") {
+                    let startTime = Date()
+                    expect("test").toAfterTimeout(equal("test"), timeout: 1.7)
+                    let secondsPaseed = Date().timeIntervalSince(startTime)
+                    expect(secondsPaseed).to(beGreaterThan(1.5))
+                    expect(secondsPaseed).to(beLessThan(1.9))
+                }
+
+                it("should evaluate expectation only once") {
+                    var evalCount = 0
+                    let testClosure: () -> Int = {
+                        evalCount += 1
+                        return evalCount
+                    }
+                    expect(testClosure()).toAfterTimeout(equal(1))
+                    expect(evalCount).to(equal(1))
+                }
+            }
+
+            context("toAfterTimeoutNot()") {
+
+                it("should finish after expected default timeout (1s)") {
+                    let startTime = Date()
+                    expect("test").toAfterTimeoutNot(haveCount(1))
+                    let secondsPaseed = Date().timeIntervalSince(startTime)
+                    expect(secondsPaseed).to(beGreaterThan(0.8))
+                    expect(secondsPaseed).to(beLessThan(1.2))
+                }
+
+                it("should finish after expected timeout") {
+                    let startTime = Date()
+                    expect("test").toAfterTimeoutNot(beEmpty(), timeout: 1.7)
+                    let secondsPaseed = Date().timeIntervalSince(startTime)
+                    expect(secondsPaseed).to(beGreaterThan(1.5))
+                    expect(secondsPaseed).to(beLessThan(1.9))
+                }
+
+                it("should evaluate expectation only once") {
+                    var evalCount = 0
+                    let testClosure: () -> Int = {
+                        evalCount += 1
+                        return evalCount
+                    }
+                    expect(testClosure()).toAfterTimeoutNot(beGreaterThan(1))
+                    expect(evalCount).to(equal(1))
+                }
+            }
+        }
+
+        describe("global extension methods") {
+
+            context("elementsEqualOrderAgnostic()") {
+
+                it("should succeed if elements are in the same order") {
+                    expect([1, 2, 3]).to(elementsEqualOrderAgnostic([1, 2, 3]))
+                }
+
+                it("should succeed if elements are not in the same order") {
+                    expect([1, 2, 3]).to(elementsEqualOrderAgnostic([1, 3, 1]))
+                }
+
+                it("should succeed for empty collections") {
+                    expect([String]()).to(elementsEqualOrderAgnostic([String]()))
+                }
+
+                it("should not succeed if elements number does not match") {
+                    expect([1, 2, 3]).toNot(elementsEqualOrderAgnostic([1, 2]))
+                    expect([1, 2, 3]).toNot(elementsEqualOrderAgnostic([1, 2, 3, 4]))
+                    expect([1, 2, 3]).toNot(elementsEqualOrderAgnostic([]))
+                }
+            }
+        }
+    }
+}

--- a/Tests/Tests/URLSessionMockSpec.swift
+++ b/Tests/Tests/URLSessionMockSpec.swift
@@ -1,0 +1,265 @@
+import Foundation
+import Quick
+import Nimble
+#if canImport(RSDKUtils)
+@testable import RSDKUtils // Cocoapods version
+#else
+@testable import RSDKUtilsMain
+@testable import RSDKUtilsTestHelpers
+#endif
+
+final class URLSessionMockSpec: QuickSpec {
+
+    override func spec() {
+        describe("URLSessionMock") {
+
+            var originalSession: URLSession!
+            var sessionMock: URLSessionMock!
+
+            beforeEach {
+                originalSession = URLSession(configuration: .ephemeral)
+                sessionMock = URLSessionMock.mock(originalInstance: originalSession)
+            }
+
+            it("should return the same mock instance for the same url session") {
+                expect(URLSessionMock.mock(originalInstance: originalSession)).to(beIdenticalTo(sessionMock))
+            }
+
+            it("should use originalSession if startMockingURLSession() was not called") {
+                sessionMock.httpResponse = HTTPURLResponse(url: URL(string: "some.url")!,
+                                                           statusCode: 500,
+                                                           httpVersion: nil,
+                                                           headerFields: nil)
+                waitUntil { done in
+                    originalSession.dataTask(with: URLRequest(url: URL(string: "about:blank")!)) { _, response, _ in
+                        expect(response?.url?.absoluteString).to(equal("about:blank"))
+                        expect(response).toNot(beAKindOf(HTTPURLResponse.self))
+                        done()
+                    }.resume()
+                }
+                expect(sessionMock.sentRequest).to(beNil())
+            }
+
+            it("should use originalSession if stopMockingURLSession() was called") {
+                URLSessionMock.startMockingURLSession()
+                sessionMock.httpResponse = HTTPURLResponse(url: URL(string: "some.url")!,
+                                                           statusCode: 500,
+                                                           httpVersion: nil,
+                                                           headerFields: nil)
+                URLSessionMock.stopMockingURLSession()
+                waitUntil { done in
+                    originalSession.dataTask(with: URLRequest(url: URL(string: "about:blank")!)) { _, response, _ in
+                        expect(response?.url?.absoluteString).to(equal("about:blank"))
+                        expect(response).toNot(beAKindOf(HTTPURLResponse.self))
+                        done()
+                    }.resume()
+                }
+                expect(sessionMock.sentRequest).to(beNil())
+            }
+
+            context("when startMockingURLSession() was called") {
+                beforeEach {
+                    URLSessionMock.startMockingURLSession()
+                }
+
+                it("should return mocked values in dataTask completion") {
+                    let expectedResponse = HTTPURLResponse(url: URL(string: "some.url")!,
+                                                           statusCode: 500,
+                                                           httpVersion: nil,
+                                                           headerFields: nil)
+                    let expectedError = NSError(domain: "mock.domain", code: 1234, userInfo: ["user": "info"])
+                    let expectedData = "data".data(using: .utf8)
+                    sessionMock.httpResponse = expectedResponse
+                    sessionMock.responseError = expectedError
+                    sessionMock.responseData = expectedData
+
+                    waitUntil { done in
+                        originalSession.dataTask(with: URLRequest(url: URL(string: "https://google.com")!)) { data, response, error in
+                            expect(data).to(equal(expectedData))
+                            expect(error as NSError?).to(equal(expectedError))
+                            expect(response).to(equal(expectedResponse))
+                            done()
+                        }.resume()
+                    }
+                }
+
+                it("should call onCompletedTask when the task is finished") {
+                    var onCompletedTaskCalled = false
+                    sessionMock.onCompletedTask = {onCompletedTaskCalled = true }
+                    waitUntil { done in
+                        originalSession.dataTask(with: URLRequest(url: URL(string: "https://google.com")!)) { _, _, _ in
+                            done()
+                        }.resume()
+                    }
+
+                    expect(onCompletedTaskCalled).to(beTrue())
+                }
+
+                it("should keep a copy of last URLRequest in `sentRequest` var") {
+                    let request = URLRequest(url: URL(string: "https://google.com")!)
+                    expect(sessionMock.sentRequest).to(beNil())
+                    waitUntil { done in
+                        originalSession.dataTask(with: request) { _, _, _ in
+                            done()
+                        }.resume()
+                    }
+
+                    expect(sessionMock.sentRequest).toNot(beNil())
+                    expect(sessionMock.sentRequest).to(equal(request))
+                }
+
+                context("when calling decodeSentData()") {
+
+                    it("should succeed if all expected parameters are present") {
+                        let jsonData = """
+                        {"identifier":100, "isTest":true, "appVersion":"1.2.3", "sdkVersion":"0.0.5"}
+                        """.data(using: .utf8)!
+
+                        var request = URLRequest(url: URL(string: "https://google.com")!)
+                        request.httpBody = jsonData
+                        waitUntil { done in
+                            originalSession.dataTask(with: request) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+
+                        let decodedModel = sessionMock.decodeSentData(modelType: BodyModel.self)
+                        expect(decodedModel).toNot(beNil())
+                        expect(decodedModel?.identifier).to(equal(100))
+                        expect(decodedModel?.isTest).to(beTrue())
+                        expect(decodedModel?.appVersion).to(equal("1.2.3"))
+                        expect(decodedModel?.sdkVersion).to(equal("0.0.5"))
+                    }
+
+                    it("should succeed if there are optional parameters in the json") {
+                        let jsonData = """
+                        {"identifier":100, "isTest":true, "appVersion":"1.2.3", "sdkVersion":"0.0.5", "locale":"pl"}
+                        """.data(using: .utf8)!
+
+                        var request = URLRequest(url: URL(string: "https://google.com")!)
+                        request.httpBody = jsonData
+                        waitUntil { done in
+                            originalSession.dataTask(with: request) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+
+                        let decodedModel = sessionMock.decodeSentData(modelType: BodyModel.self)
+                        expect(decodedModel).toNot(beNil())
+                        expect(decodedModel?.identifier).to(equal(100))
+                        expect(decodedModel?.isTest).to(beTrue())
+                        expect(decodedModel?.appVersion).to(equal("1.2.3"))
+                        expect(decodedModel?.sdkVersion).to(equal("0.0.5"))
+                    }
+
+                    it("should fail if not all expected parameters are present") {
+                        let jsonData = """
+                        {"identifier":100, "isTest":true, "appVersion":"1.2.3"}
+                        """.data(using: .utf8)!
+
+                        var request = URLRequest(url: URL(string: "https://google.com")!)
+                        request.httpBody = jsonData
+                        waitUntil { done in
+                            originalSession.dataTask(with: request) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+
+                        let decodedModel = sessionMock.decodeSentData(modelType: BodyModel.self)
+                        expect(decodedModel).to(beNil())
+                    }
+
+                    it("should fail if parameter type does not match") {
+                        let jsonData = """
+                        {"identifier":"id", "isTest":true, "appVersion":"1.2.3", "sdkVersion":"0.0.5"}
+                        """.data(using: .utf8)!
+
+                        var request = URLRequest(url: URL(string: "https://google.com")!)
+                        request.httpBody = jsonData
+                        waitUntil { done in
+                            originalSession.dataTask(with: request) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+
+                        let decodedModel = sessionMock.decodeSentData(modelType: BodyModel.self)
+                        expect(decodedModel).to(beNil())
+                    }
+                }
+
+                context("when calling decodeQueryItems()") {
+
+                    it("should succeed if all expected parameters are present") {
+                        let urlQuery = URL(string: "http://config.url?isTest=true&identifier=100&appVersion=1.2.3&sdkVersion=0.0.5")!
+
+                        waitUntil { done in
+                            originalSession.dataTask(with: URLRequest(url: urlQuery)) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+                        let decodedModel = sessionMock.decodeQueryItems(modelType: URLQueryModel.self)
+                        expect(decodedModel).toNot(beNil())
+                        expect(decodedModel?.identifier).to(equal(100))
+                        expect(decodedModel?.isTest).to(beTrue())
+                        expect(decodedModel?.appVersion).to(equal("1.2.3"))
+                        expect(decodedModel?.sdkVersion).to(equal("0.0.5"))
+                    }
+
+                    it("should succeed if there are optional parameters in the url") {
+                        let urlQuery = URL(string: "http://config.url?isTest=true&identifier=100&appVersion=1.2.3&sdkVersion=0.0.5&locale=pl")!
+
+                        waitUntil { done in
+                            originalSession.dataTask(with: URLRequest(url: urlQuery)) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+                        let decodedModel = sessionMock.decodeQueryItems(modelType: URLQueryModel.self)
+                        expect(decodedModel).toNot(beNil())
+                        expect(decodedModel?.identifier).to(equal(100))
+                        expect(decodedModel?.isTest).to(beTrue())
+                        expect(decodedModel?.appVersion).to(equal("1.2.3"))
+                        expect(decodedModel?.sdkVersion).to(equal("0.0.5"))
+                    }
+
+                    it("should fail if not all expected parameters are present") {
+                        let urlQuery = URL(string: "http://config.url?isTest=true&identifier=100&appVersion=1.2.3")!
+
+                        waitUntil { done in
+                            originalSession.dataTask(with: URLRequest(url: urlQuery)) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+                        let decodedModel = sessionMock.decodeQueryItems(modelType: URLQueryModel.self)
+                        expect(decodedModel).to(beNil())
+                    }
+
+                    it("should fail if parameter type does not match") {
+                        let urlQuery = URL(string: "http://config.url?isTest=true&identifier=id&appVersion=1.2.3&sdkVersion=0.0.5")!
+
+                        waitUntil { done in
+                            originalSession.dataTask(with: URLRequest(url: urlQuery)) { _, _, _ in
+                                done()
+                            }.resume()
+                        }
+                        let decodedModel = sessionMock.decodeQueryItems(modelType: URLQueryModel.self)
+                        expect(decodedModel).to(beNil())
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal struct URLQueryModel: Codable {
+    let identifier: Int
+    let isTest: Bool
+    let appVersion: String
+    let sdkVersion: String
+}
+
+private struct BodyModel: Codable {
+    let identifier: Int
+    let isTest: Bool
+    let appVersion: String
+    let sdkVersion: String
+}

--- a/Tests/Tests/XCTestExtensionsSpec.swift
+++ b/Tests/Tests/XCTestExtensionsSpec.swift
@@ -16,12 +16,12 @@ final class XCTestExtensionsSpec: QuickSpec {
 
             context("eventually(after:this:shouldEqual)") {
 
-                it("should succeed immediately if values were equal from the beginning") {
+                it("should succeed without adding any delay if values were equal from the beginning") {
                     let startTime = Date()
                     self.eventually(this: { "test" }, shouldEqual: { "test" })
 
-                    let secondsPaseed = Date().timeIntervalSince(startTime)
-                    expect(secondsPaseed).to(beLessThan(0.2))
+                    let secondsPassed = Date().timeIntervalSince(startTime)
+                    expect(secondsPassed).to(beLessThanOrEqualTo(0.1))
                 }
 
                 it("should succeed if values become equal") {
@@ -34,12 +34,13 @@ final class XCTestExtensionsSpec: QuickSpec {
 
                 it("should fail after expected timeout if values did not become equal") {
                     let startTime = Date()
-                    XCTExpectFailure()
-                    self.eventually(after: 2, this: { "test" }, shouldEqual: { "test2" })
+                    XCTExpectFailure {
+                        self.eventually(after: 2, this: { "test" }, shouldEqual: { "test2" })
+                    }
 
-                    let secondsPaseed = Date().timeIntervalSince(startTime)
-                    expect(secondsPaseed).to(beGreaterThan(1.8))
-                    expect(secondsPaseed).to(beLessThan(2.2))
+                    let secondsPassed = Date().timeIntervalSince(startTime)
+                    expect(secondsPassed).to(beGreaterThanOrEqualTo(2.0))
+                    expect(secondsPassed).to(beLessThanOrEqualTo(2.2))
                 }
 
                 it("should evaluate (poll) expectation multiple times") {

--- a/Tests/Tests/XCTestExtensionsSpec.swift
+++ b/Tests/Tests/XCTestExtensionsSpec.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Quick
+import Nimble
+import XCTest
+#if canImport(RSDKUtils)
+@testable import RSDKUtils // Cocoapods version
+#else
+@testable import RSDKUtilsMain
+@testable import RSDKUtilsTestHelpers
+#endif
+
+final class XCTestExtensionsSpec: QuickSpec {
+
+    override func spec() {
+        describe("XCTest extensions") {
+
+            context("eventually(after:this:shouldEqual)") {
+
+                it("should succeed immediately if values were equal from the beginning") {
+                    let startTime = Date()
+                    self.eventually(this: { "test" }, shouldEqual: { "test" })
+
+                    let secondsPaseed = Date().timeIntervalSince(startTime)
+                    expect(secondsPaseed).to(beLessThan(0.2))
+                }
+
+                it("should succeed if values become equal") {
+                    var value: String?
+                    DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(1)) {
+                        value = "test"
+                    }
+                    self.eventually(this: { value }, shouldEqual: { "test" })
+                }
+
+                it("should fail after expected timeout if values did not become equal") {
+                    let startTime = Date()
+                    XCTExpectFailure()
+                    self.eventually(after: 2, this: { "test" }, shouldEqual: { "test2" })
+
+                    let secondsPaseed = Date().timeIntervalSince(startTime)
+                    expect(secondsPaseed).to(beGreaterThan(1.8))
+                    expect(secondsPaseed).to(beLessThan(2.2))
+                }
+
+                it("should evaluate (poll) expectation multiple times") {
+                    var evalCount = 0
+                    let testClosure: () -> Int? = {
+                        evalCount += 1
+                        return min(evalCount, 3) // I put a limit so the final XCTAssertEqual does not increment the value any further
+                    }
+                    self.eventually(this: testClosure, shouldEqual: { 3 })
+                }
+            }
+        }
+    }
+}

--- a/Tests/Tests/XCTestExtensionsSpec.swift
+++ b/Tests/Tests/XCTestExtensionsSpec.swift
@@ -21,7 +21,7 @@ final class XCTestExtensionsSpec: QuickSpec {
                     self.eventually(this: { "test" }, shouldEqual: { "test" })
 
                     let secondsPassed = Date().timeIntervalSince(startTime)
-                    expect(secondsPassed).to(beLessThanOrEqualTo(0.1))
+                    expect(secondsPassed.rounded()).to(beLessThanOrEqualTo(0.1))
                 }
 
                 it("should succeed if values become equal") {
@@ -39,8 +39,8 @@ final class XCTestExtensionsSpec: QuickSpec {
                     }
 
                     let secondsPassed = Date().timeIntervalSince(startTime)
-                    expect(secondsPassed).to(beGreaterThanOrEqualTo(2.0))
-                    expect(secondsPassed).to(beLessThanOrEqualTo(2.2))
+                    expect(secondsPassed.rounded()).to(beGreaterThanOrEqualTo(2.0))
+                    expect(secondsPassed.rounded()).to(beLessThanOrEqualTo(2.2))
                 }
 
                 it("should evaluate (poll) expectation multiple times") {


### PR DESCRIPTION
- Improved tests coverage from ~63% to ~82% (Xcode report) for SonarQube quality gate
- Made Danger report the same coverage by removing .xcovignore file