### PR TITLE
fix: fix Bundle.sdkVersion() returning only RSDKUtils bundle version

### DIFF
--- a/Sources/RSDKUtilsMain/Extensions/Bundle+EnvironmentInformation.swift
+++ b/Sources/RSDKUtilsMain/Extensions/Bundle+EnvironmentInformation.swift
@@ -32,7 +32,7 @@ extension Bundle: BundleProtocol {
     }
 
     public func sdkVersion() -> String {
-        Bundle(for: EnvironmentInformation.self).value(for: "CFBundleShortVersionString") ?? valueNotFound
+        self.value(for: "CFBundleShortVersionString") ?? valueNotFound
     }
 
     public func value(for key: String) -> String? {


### PR DESCRIPTION
`Bundle(for: EnvironmentInformation.self).value(for: "CFBundleShortVersionString")` always returns version of RSDKUtils instead of version of `self` bundle (SDK)