### PR TITLE
improve: Remove RLogger deprecated functions (SDKCF-5579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # **Changelog**
 
+#### 4.0.0 (TBC)
+- Deletion:
+    - RLogger deprecated functions were removed.
+
 #### 3.0.0 (2022-04-06)
 - Features:
     - Align iOS version (SDKCF-5011)

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ To use the module in its basic configuration your `Podfile` should contain:
 
 ```ruby
 # Defined also as 'RSDKUtils/Main'
-pod 'RSDKUtils', :git => '~> 3.0.0'
+pod 'RSDKUtils', :git => '~> 4.0.0'
 ```
 
 To use other functionalities, add their respective subspec to your `Podfile`:
 ```ruby
-pod 'RSDKUtils/TestHelpers', '~> 3.0.0'
-pod 'RSDKUtils/Nimble', '~> 3.0.0'
-pod 'RSDKUtils/RLogger', '~> 3.0.0'
+pod 'RSDKUtils/TestHelpers', '~> 4.0.0'
+pod 'RSDKUtils/Nimble', '~> 4.0.0'
+pod 'RSDKUtils/RLogger', '~> 4.0.0'
 ```
 
 Run `pod install` to install the module.<br>
@@ -50,7 +50,7 @@ More information on installing pods: [https://guides.cocoapods.org/using/getting
 ## Installing with Swift Package Manager
 Open your project settings in Xcode and add a new package in 'Swift Packages' tab:
 * Repository URL: `https://github.com/rakutentech/ios-sdkutils.git`
-* Version settings: branch `master` or 3.0.0 "Up to Next Major" 
+* Version settings: branch `master` or 4.0.0 "Up to Next Major" 
 
 Choose one of the following products for your target:
 * RSDKUtilsMain
@@ -99,6 +99,6 @@ This usually happens when `TestHelpers` or `Nimble` subspec is linked only to te
 The solution for that is to link `TestHelpers` and `Nimble` spec to the Host app target either explicitly or as a `testspecs`.
 ```ruby
 target 'HostAppTarget'
-  pod 'RSDKUtils', '~> 3.0.0', :testspecs => ['Nimble', 'TestHelpers']
+  pod 'RSDKUtils', '~> 4.0.0', :testspecs => ['Nimble', 'TestHelpers']
 end    
 ```

--- a/RSDKUtils.podspec
+++ b/RSDKUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RSDKUtils"
-  s.version      = "3.0.0"
+  s.version      = "4.0.0"
   s.authors      = "Rakuten Ecosystem Mobile"
   s.summary      = "Rakuten's SDK Team internal utilities module."
   s.homepage     = "https://github.com/rakutentech/ios-sdkutils"

--- a/Sources/RLogger/RLogger.swift
+++ b/Sources/RLogger/RLogger.swift
@@ -69,33 +69,6 @@ public protocol Variadicable {
     @discardableResult static func error(_ format: String, arguments: CVarArg...) -> String?
 }
 
-extension RLogger: Variadicable {
-    @available(*, deprecated, message: "Use verbose(message:) instead")
-    @discardableResult public static func verbose(_ format: String, arguments: CVarArg...) -> String? {
-        log(.verbose, message: String(format: format, arguments: arguments))
-    }
-
-    @available(*, deprecated, message: "Use debug(message:) instead")
-    @discardableResult public static func debug(_ format: String, arguments: CVarArg...) -> String? {
-        log(.debug, message: String(format: format, arguments: arguments))
-    }
-
-    @available(*, deprecated, message: "Use info(message:) instead")
-    @discardableResult public static func info(_ format: String, arguments: CVarArg...) -> String? {
-        log(.info, message: String(format: format, arguments: arguments))
-    }
-
-    @available(*, deprecated, message: "Use warning(message:) instead")
-    @discardableResult public static func warning(_ format: String, arguments: CVarArg...) -> String? {
-        log(.warning, message: String(format: format, arguments: arguments))
-    }
-
-    @available(*, deprecated, message: "Use error(message:) instead")
-    @discardableResult public static func error(_ format: String, arguments: CVarArg...) -> String? {
-        log(.error, message: String(format: format, arguments: arguments))
-    }
-}
-
 internal extension RLogger {
     /// Returns the caller module name.
     ///

--- a/Tests/Tests/RLoggerSpec.swift
+++ b/Tests/Tests/RLoggerSpec.swift
@@ -24,68 +24,6 @@ class RLoggerSpec: QuickSpec {
             }
 
             describe("log(_:message:)") {
-                context("when a format and arguments are logged") {
-                    it("should return message from this level: RLoggingLevel.verbose") {
-                        RLogger.loggingLevel = .verbose
-                        expect(RLogger.verbose("test")).to(equal("test"))
-                        expect(RLogger.debug("test")).to(equal("test"))
-                        expect(RLogger.info("test")).to(equal("test"))
-                        expect(RLogger.warning("test")).to(equal("test"))
-                        expect(RLogger.error("test")).to(equal("test"))
-                        expect(RLogger.error("test %@", arguments: "hello")).to(equal("test hello"))
-                    }
-
-                    it("should return message from this level: RLoggingLevel.debug") {
-                        RLogger.loggingLevel = .debug
-                        expect(RLogger.verbose("test")).to(beNil())
-                        expect(RLogger.debug("test")).to(equal("test"))
-                        expect(RLogger.info("test")).to(equal("test"))
-                        expect(RLogger.warning("test")).to(equal("test"))
-                        expect(RLogger.error("test")).to(equal("test"))
-                        expect(RLogger.error("test %@", arguments: "hello")).to(equal("test hello"))
-                    }
-
-                    it("should return message from this level: RLoggingLevel.info") {
-                        RLogger.loggingLevel = .info
-                        expect(RLogger.verbose("test")).to(beNil())
-                        expect(RLogger.debug("test")).to(beNil())
-                        expect(RLogger.info("test")).to(equal("test"))
-                        expect(RLogger.warning("test")).to(equal("test"))
-                        expect(RLogger.error("test")).to(equal("test"))
-                        expect(RLogger.error("test %@", arguments: "hello")).to(equal("test hello"))
-                    }
-
-                    it("should return message from this level: RLoggingLevel.warning") {
-                        RLogger.loggingLevel = .warning
-                        expect(RLogger.verbose("test")).to(beNil())
-                        expect(RLogger.debug("test")).to(beNil())
-                        expect(RLogger.info("test")).to(beNil())
-                        expect(RLogger.warning("test")).to(equal("test"))
-                        expect(RLogger.error("test")).to(equal("test"))
-                        expect(RLogger.error("test %@", arguments: "hello")).to(equal("test hello"))
-                    }
-
-                    it("should return message from this level: RLoggingLevel.error") {
-                        RLogger.loggingLevel = .error
-                        expect(RLogger.verbose("test")).to(beNil())
-                        expect(RLogger.debug("test")).to(beNil())
-                        expect(RLogger.info("test")).to(beNil())
-                        expect(RLogger.warning("test")).to(beNil())
-                        expect(RLogger.error("test")).to(equal("test"))
-                        expect(RLogger.error("test %@", arguments: "hello")).to(equal("test hello"))
-                    }
-
-                    it("should return message from this level: RLoggingLevel.none") {
-                        RLogger.loggingLevel = .none
-                        expect(RLogger.verbose("test")).to(beNil())
-                        expect(RLogger.debug("test")).to(beNil())
-                        expect(RLogger.info("test")).to(beNil())
-                        expect(RLogger.warning("test")).to(beNil())
-                        expect(RLogger.error("test")).to(beNil())
-                        expect(RLogger.error("test %@", arguments: "hello")).to(beNil())
-                    }
-                }
-
                 context("when a message is logged") {
                     it("should return message from this level: RLoggingLevel.verbose") {
                         RLogger.loggingLevel = .verbose


### PR DESCRIPTION
## Description
Remove RLogger deprecated functions

## Notes
This PR introduces a Public API breaking change.
Therefore the next version of RSDKUtils is 4.0.0

## Links
SDKCF-5579