### PR TITLE
build: use xcpretty to fix fastlane test report generation format (SDKCF-5616)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem "fastlane"
 gem "cocoapods"
 gem "xcov", ">= 1.7.3", "< 2.0.0"
 gem "danger"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,6 +22,7 @@ platform :ios do
       scheme: ENV['REM_FL_TESTS_SCHEME'] || 'Tests',
       device: ENV['REM_FL_TESTS_DEVICE'] || 'iPhone 11',
       code_coverage: true,
+      xcodebuild_formatter: 'xcpretty',
       output_types: 'json-compilation-database,html,junit',
       output_files: 'compile_commands.json,report.html,report.junit')
 


### PR DESCRIPTION
Bitrise has `xcbeautify` installed which fits the default Fastlane setting (it doesn't fallback to xcpretty).
Using xcpretty is necessary to avoid following issues:
```
[22:59:24]: Skipping HTML... only available with `xcodebuild_formatter: 'xcpretty'` right now
[22:59:24]: Skipping JSON Compilation Database... only available with `xcodebuild_formatter: 'xcpretty'` right now
[22:59:24]: Your 'xcodebuild_formatter' doesn't support these 'output_types'. Change your 'output_types' to prevent these warnings from showing...
```
This has an impact on Bitrise test report format.