### PR TITLE
chore: update swiftlint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -43,4 +43,8 @@ cyclomatic_complexity:
     warning: 15
     error: 25
 
+large_tuple:
+    warning: 4
+    error: 4
+
 reporter: "xcode"

--- a/RSDKUtils.xcodeproj/project.pbxproj
+++ b/RSDKUtils.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint --config \"${SRCROOT}/.swiftlint.yml\"\n";
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\" lint --config \"${SRCROOT}/.swiftlint.yml\" --strict\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Added `large_tuple` rule to fix errors with new swiftlint version and also keep the source code working with older swiftlint (0.48) version which we still support as a part of Xcode 12.5 support.

The large_tuple error was raised in `isRGBAEqual()` function in `UIColor+Extensions.swift` file