### PR TITLE
chore: remove failing test (SDKCF-5988)

### DIFF
--- a/Tests/Tests/XCTestExtensionsSpec.swift
+++ b/Tests/Tests/XCTestExtensionsSpec.swift
@@ -32,18 +32,6 @@ final class XCTestExtensionsSpec: QuickSpec {
                     self.eventually(this: { value }, shouldEqual: { "test" })
                 }
 
-                // Disable failing test
-//                it("should fail after expected timeout if values did not become equal") {
-//                    let startTime = Date()
-//                    XCTExpectFailure {
-//                        self.eventually(after: 2, this: { "test" }, shouldEqual: { "test2" })
-//                    }
-//
-//                    let secondsPassed = Date().timeIntervalSince(startTime)
-//                    expect(secondsPassed.rounded()).to(beGreaterThanOrEqualTo(2.0))
-//                    expect(secondsPassed.rounded()).to(beLessThanOrEqualTo(2.2))
-//                }
-
                 it("should evaluate (poll) expectation multiple times") {
                     var evalCount = 0
                     let testClosure: () -> Int? = {


### PR DESCRIPTION
After I uncomment the code, I think it work as expected:
![image](https://github.com/rakutentech/ios-sdkutils/assets/121004972/ab94940b-477b-46fe-a651-c25e644431e6)

There's no failure that marks success in the Xcode.
Xcode marks the test as an expected failure instead of a test failure. Source: [apple](https://developer.apple.com/documentation/xctest/expected_failures)

> 💡  While doing some refactoring piece of code, it’s common to run into failing tests while the code is still being refactored. Up until we could use XCTExpectFailure I would disable those tests and only run them once I expected them to succeed. [source](https://www.avanderlee.com/swift/xctexpectfailure-expected-failures/#why-would-you-use-xctexpectfailure)

**XCTExpectFailure is used temporarily to disable or skip the code until we can fix that, not for testing.**

Reasons for using XCTExpectFailure over XCTSkip

Well, there’s an important difference to consider when using XCTSkip instead of XCTExpectFailure. A skipped or disabled test will always be skipped, even if you’re done refactoring and your test would succeed again.

When using XCTExpectFailure, you give yourself a checkpoint that informs you to re-enable a test. If our avatar color correctly returns blue again but we still have our expected failure configured, Xcode will inform us with a failing test. [source](https://www.avanderlee.com/swift/xctexpectfailure-expected-failures/#why-would-you-use-xctexpectfailure)

—

Conclusions:

We can remove this test case.

If we still want to achieve the incorrect check but make Xcode marks the test as successful, maybe we can make a function like `eventuallyNot` to check whether the value will not be equal after a timeout.