### PR TITLE
fix: fix XCTest linking error for some watchOS targets

### DIFF
--- a/Sources/RSDKUtilsTestHelpers/Extensions/XCTest+Eventually.swift
+++ b/Sources/RSDKUtilsTestHelpers/Extensions/XCTest+Eventually.swift
@@ -1,3 +1,4 @@
+#if os(macOS) || os(iOS)
 import Foundation
 import XCTest
 
@@ -27,3 +28,4 @@ public extension XCTestCase {
         XCTAssertEqual(value(), otherValue())
     }
 }
+#endif


### PR DESCRIPTION
A fix for `pod lib lint` error:
```
ld: warning: ignoring file /Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib, file is universal (x86_64,arm64) but does not contain the i386 architecture: /Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/usr/lib/libXCTestSwiftSupport.dylib
    ld: warning: ignoring file /Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/XCTest.framework/XCTest, file is universal (x86_64,arm64) but does not contain the i386 architecture: /Applications/Xcode.app/Contents/Developer/Platforms/WatchSimulator.platform/Developer/Library/Frameworks/XCTest.framework/XCTest
    Undefined symbols for architecture i386:
      "_$s6XCTest14XCTAssertEqual___4file4lineyxyKXK_xyKXKSSyXKs12StaticStringVSutSQRzlF", referenced from:
          _$sSo10XCTestCaseC9RSDKUtilsE10eventually5after4this11shouldEqualySd_xSgycxyctSQRzlF in XCTest+Eventually.o
         (maybe you meant: _$s6XCTest14XCTAssertEqual___4file4lineyxyKXK_xyKXKSSyXKs12StaticStringVSutSQRzlFfA1_SSycfu_)
      "_OBJC_CLASS_$_XCTestExpectation", referenced from:
          objc-class-ref in XCTest+Eventually.o
      "__swift_FORCE_LOAD_$_XCTestSwiftSupport", referenced from:
          __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils in AnalyticsBroadcaster.o
          __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils in AnyDependenciesContainer.o
          __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils in AtomicWrapper.o
          __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils in Bundle+EnvironmentInformation.o
          __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils in Data+Extensions.o
          __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils in Dictionary+Extensions.o
          __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils in EnvironmentInformation.o
          ...
         (maybe you meant: __swift_FORCE_LOAD_$_XCTestSwiftSupport_$_RSDKUtils)
    ld: symbol(s) not found for architecture i386
    clang: error: linker command failed with exit code 1 (use -v to see invocation)
 ```